### PR TITLE
Fix notification open event fire twice

### DIFF
--- a/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -71,7 +71,7 @@ public class RNNotificationsPackage implements ReactPackage, AppLifecycleFacade.
 
     @Override
     public void onActivityStarted(Activity activity) {
-        if (InitialNotificationHolder.getInstance().get() == null) {
+        if (InitialNotificationHolder.getInstance().get() == null && !NotificationIntentAdapter.cannotHandleTrampolineActivity(appContext)) {
             callOnOpenedIfNeed(activity);
         }
     }
@@ -104,6 +104,7 @@ public class RNNotificationsPackage implements ReactPackage, AppLifecycleFacade.
                     NotificationIntentAdapter.extractPendingNotificationDataFromIntent(intent) : intent.getExtras();
             final IPushNotification pushNotification = PushNotification.get(appContext, notificationData);
             if (pushNotification != null) {
+                Log.d(LOGTAG, "Calling onOpened for notification: ");
                 pushNotification.onOpened();
             }
         }

--- a/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
@@ -14,7 +14,7 @@ public class NotificationIntentAdapter {
 
     @SuppressLint("UnspecifiedImmutableFlag")
     public static PendingIntent createPendingNotificationIntent(Context appContext, PushNotificationProps notification) {
-          if (cannotHandleTrampolineActivity(appContext)) {
+        if (cannotHandleTrampolineActivity(appContext)) {
             Intent mainActivityIntent = appContext.getPackageManager().getLaunchIntentForPackage(appContext.getPackageName());
             mainActivityIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
             mainActivityIntent.putExtra(PUSH_NOTIFICATION_EXTRA_NAME, notification.asBundle());
@@ -41,9 +41,9 @@ public class NotificationIntentAdapter {
     public static boolean canHandleIntent(Intent intent) {
         if (intent != null) {
             Bundle notificationData = intent.getExtras();
-            if (notificationData != null && intent.hasExtra(PUSH_NOTIFICATION_EXTRA_NAME)) {
-                return true;
-            }
+            return notificationData != null &&
+                    (intent.hasExtra(PUSH_NOTIFICATION_EXTRA_NAME) ||
+                            notificationData.getString("google.message_id", null) != null);
         }
 
         return false;


### PR DESCRIPTION
Solves the OnNotificationOpened fired twice when tapping the second notification with the app in the background